### PR TITLE
Fix task view column label alignment

### DIFF
--- a/internal/tui/components/tasklist.go
+++ b/internal/tui/components/tasklist.go
@@ -593,7 +593,7 @@ func (t TaskList) renderTaskLine(task core.Task, isCursor bool, isMultiSelected 
 		"description": description,
 	}
 
-	parts := []string{cursor}
+	parts := []string{cursor + " "}
 	for _, col := range t.displayColumns {
 		value := columnValues[col]
 		width := cols.widths[col]


### PR DESCRIPTION
Fixed misalignment between column headers and data rows in the task view. The cursor column was 1 character in data rows but 2 spaces in the header, causing all columns to shift left by 1 space.

Changed data row cursor from single character to character + space to match the cursorWidth constant (2 chars) and header spacing.

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### What this PR does / why we need it:
<!-- A clear description of the problem you are trying to solve -->


#### Changes made
<!-- Outline the specific changes made in this merge request. -->


#### Which issue(s) this PR fixes:
<!--
Any reference to relevant issue(s). Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please describe the tests that you ran to verify your changes.
It would be great if you could add the tests as unittests and/or e2e tests. This will help us to ensure that your changes are working as expected and will not break in the future.
-->
