### PR TITLE
Create Tasks from Calendar events during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,36 @@ wui sync --calendar "Urgent" --filter "+urgent priority:H"
 
 ### How it works
 
-- Tasks are synced as all-day events in Google Calendar
+**Bidirectional Sync**: The sync works in both directions:
+
+**Calendar → Taskwarrior**:
+- Manually created calendar events are automatically converted to tasks
+- Event title becomes the task description
+- Event date/time becomes the task due date/time
+- Optional metadata in event description:
+  - `Project:<project name>` - Sets the task project
+  - `Tags: <tag1>, <tag2>` - Adds tags to the task (comma-separated)
+- After conversion, the event is updated with the task UUID to prevent duplicates
+
+**Taskwarrior → Calendar**:
+- Tasks are synced as calendar events based on their due or scheduled dates
 - Each event includes the task UUID, project, tags, and status in its description
-- Event dates are based on the task's due date, or scheduled date if no due date is set
 - Completed tasks are marked with a ✓ checkmark in the title
 - Events are color-coded based on priority (red for high, yellow for medium)
 - Existing events are updated if the task changes
-- The sync is one-way: Taskwarrior → Google Calendar
+
+**Time Handling**:
+- All-day events ↔ Tasks with date only (e.g., `due:2026-01-15`)
+- Timed events ↔ Tasks with datetime (e.g., `due:2026-01-15T14:30:00`)
+- **Important**: Tasks with times at exactly midnight (00:00:00) are treated as all-day events
+- Time information is preserved bidirectionally for non-midnight times
+
+**Example**: Create a calendar event titled "Team Meeting" on Jan 15 at 2:30 PM with description:
+```
+Project:work
+Tags: meeting, urgent
+```
+After sync, this creates: `task add "Team Meeting" project:work +meeting +urgent due:2026-01-15T14:30:00`
 
 ## Filtering
 

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -230,12 +230,14 @@ func (s *SyncClient) taskToEvent(task core.Task) *calendar.Event {
 			Date: eventTime.Format("2006-01-02"),
 		}
 	} else {
-		// Create timed event
+		// Create timed event with 1-hour duration
+		// (Google Calendar requires end time != start time for timed events)
+		endTime := eventTime.Add(time.Hour)
 		event.Start = &calendar.EventDateTime{
 			DateTime: eventTime.Format(time.RFC3339),
 		}
 		event.End = &calendar.EventDateTime{
-			DateTime: eventTime.Format(time.RFC3339),
+			DateTime: endTime.Format(time.RFC3339),
 		}
 	}
 

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -230,9 +230,9 @@ func (s *SyncClient) taskToEvent(task core.Task) *calendar.Event {
 			Date: eventTime.Format("2006-01-02"),
 		}
 	} else {
-		// Create timed event with 1-hour duration
+		// Create timed event with 15-minute duration
 		// (Google Calendar requires end time != start time for timed events)
-		endTime := eventTime.Add(time.Hour)
+		endTime := eventTime.Add(15 * time.Minute)
 		event.Start = &calendar.EventDateTime{
 			DateTime: eventTime.Format(time.RFC3339),
 		}

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -372,22 +372,23 @@ func (s *SyncClient) createTaskFromEvent(ctx context.Context, calendarID string,
 		taskDesc = fmt.Sprintf("%s +%s", taskDesc, tag)
 	}
 
-	// Extract date from event
+	// Extract date/time from event
 	var dueDate string
 	if event.Start != nil {
 		if event.Start.Date != "" {
-			// All-day event
+			// All-day event - use date only
 			dueDate = event.Start.Date
 		} else if event.Start.DateTime != "" {
-			// Timed event - parse and format as date
+			// Timed event - preserve time information
 			t, err := time.Parse(time.RFC3339, event.Start.DateTime)
 			if err == nil {
-				dueDate = t.Format("2006-01-02")
+				// Format as ISO 8601 datetime for Taskwarrior
+				dueDate = t.Format("2006-01-02T15:04:05")
 			}
 		}
 	}
 
-	// Add due date if available
+	// Add due date/time if available
 	if dueDate != "" {
 		taskDesc = fmt.Sprintf("%s due:%s", taskDesc, dueDate)
 	}

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -469,8 +469,9 @@ func (s *SyncClient) createTaskFromEvent(ctx context.Context, calendarID string,
 			// Timed event - preserve time information
 			t, err := time.Parse(time.RFC3339, event.Start.DateTime)
 			if err == nil {
-				// Format as ISO 8601 datetime for Taskwarrior
-				dueDate = t.Format("2006-01-02T15:04:05")
+				// Convert to local time before formatting for Taskwarrior
+				localTime := t.Local()
+				dueDate = localTime.Format("2006-01-02T15:04:05")
 			}
 		}
 	}

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -219,12 +219,24 @@ func (s *SyncClient) taskToEvent(task core.Task) *calendar.Event {
 		eventTime = *task.Scheduled
 	}
 
-	// Create all-day event
-	event.Start = &calendar.EventDateTime{
-		Date: eventTime.Format("2006-01-02"),
-	}
-	event.End = &calendar.EventDateTime{
-		Date: eventTime.Format("2006-01-02"),
+	// Check if the time has specific hour/minute (not just midnight)
+	// If it's exactly midnight (00:00:00), treat it as an all-day event
+	if eventTime.Hour() == 0 && eventTime.Minute() == 0 && eventTime.Second() == 0 {
+		// Create all-day event
+		event.Start = &calendar.EventDateTime{
+			Date: eventTime.Format("2006-01-02"),
+		}
+		event.End = &calendar.EventDateTime{
+			Date: eventTime.Format("2006-01-02"),
+		}
+	} else {
+		// Create timed event
+		event.Start = &calendar.EventDateTime{
+			DateTime: eventTime.Format(time.RFC3339),
+		}
+		event.End = &calendar.EventDateTime{
+			DateTime: eventTime.Format(time.RFC3339),
+		}
 	}
 
 	// Add color based on priority


### PR DESCRIPTION
Enable creation of Taskwarrior tasks from manually created calendar events. When syncing, the tool now:
- Detects calendar events without a Taskwarrior UUID (manually created events)
- Creates corresponding tasks with the event name, date, and time
- Parses event description for optional metadata:
  * Project:<project name>
  * Tags: <tag1>, <tag2>
- Updates the event with the newly created task UUID
- Syncs the task back to the calendar with standard formatting

This enables a bidirectional workflow where users can create events in Google Calendar and have them automatically become Taskwarrior tasks.

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### What this PR does / why we need it:
<!-- A clear description of the problem you are trying to solve -->


#### Changes made
<!-- Outline the specific changes made in this merge request. -->


#### Which issue(s) this PR fixes:
<!--
Any reference to relevant issue(s). Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please describe the tests that you ran to verify your changes.
It would be great if you could add the tests as unittests and/or e2e tests. This will help us to ensure that your changes are working as expected and will not break in the future.
-->
