### PR TITLE
Fix Ctrl+d/u keybinding descriptions and behavior

### DIFF
--- a/internal/tui/components/help.go
+++ b/internal/tui/components/help.go
@@ -210,8 +210,8 @@ func defaultKeybindingGroups() []KeybindingGroup {
 			Bindings: []Keybinding{
 				{Keys: []string{"J"}, Description: "Scroll down one line"},
 				{Keys: []string{"K"}, Description: "Scroll up one line"},
-				{Keys: []string{"Ctrl+d"}, Description: "Jump to bottom"},
-				{Keys: []string{"Ctrl+u"}, Description: "Jump to top"},
+				{Keys: []string{"Ctrl+d"}, Description: "Scroll down half page"},
+				{Keys: []string{"Ctrl+u"}, Description: "Scroll up half page"},
 				{Keys: []string{"Ctrl+f", "PgDn"}, Description: "Scroll down full page"},
 				{Keys: []string{"Ctrl+b", "PgUp"}, Description: "Scroll up full page"},
 			},
@@ -294,8 +294,8 @@ func keybindingGroupsFromConfig(keybindings map[string]string) []KeybindingGroup
 			Bindings: []Keybinding{
 				{Keys: []string{"J"}, Description: "Scroll down one line"},
 				{Keys: []string{"K"}, Description: "Scroll up one line"},
-				{Keys: []string{"Ctrl+d"}, Description: "Jump to bottom"},
-				{Keys: []string{"Ctrl+u"}, Description: "Jump to top"},
+				{Keys: []string{"Ctrl+d"}, Description: "Scroll down half page"},
+				{Keys: []string{"Ctrl+u"}, Description: "Scroll up half page"},
 				{Keys: []string{"Ctrl+f", "PgDn"}, Description: "Scroll down full page"},
 				{Keys: []string{"Ctrl+b", "PgUp"}, Description: "Scroll up full page"},
 			},

--- a/internal/tui/components/sidebar.go
+++ b/internal/tui/components/sidebar.go
@@ -89,10 +89,10 @@ func (s *Sidebar) handleKey(msg tea.KeyMsg) {
 		s.scrollDown(1)
 	case "K": // K (shift+k) for line up
 		s.scrollUp(1)
-	case "ctrl+d": // Jump to bottom
-		s.scrollToBottom()
-	case "ctrl+u": // Jump to top
-		s.scrollToTop()
+	case "ctrl+d": // Scroll down half page
+		s.scrollDown(s.height / 2)
+	case "ctrl+u": // Scroll up half page
+		s.scrollUp(s.height / 2)
 	case "ctrl+f", "pgdown": // Full page down
 		s.scrollDown(s.height)
 	case "ctrl+b", "pgup": // Full page up


### PR DESCRIPTION
## Summary
Updated the Ctrl+d and Ctrl+u keybinding descriptions and implementations to accurately reflect their behavior as half-page scrolling commands rather than jump-to-bottom/top commands.

## Changes
- **Help text corrections**: Updated keybinding descriptions in both `defaultKeybindingGroups()` and `keybindingGroupsFromConfig()` to correctly describe Ctrl+d as "Scroll down half page" and Ctrl+u as "Scroll up half page"
- **Sidebar behavior fix**: Changed the actual implementation in `sidebar.go` from `scrollToBottom()` and `scrollToTop()` to `scrollDown(s.height / 2)` and `scrollUp(s.height / 2)` to match the documented behavior
- **Consistency**: Aligned the help documentation with the actual keybinding behavior across all configuration sources

## Implementation Details
The changes ensure that Ctrl+d and Ctrl+u now scroll by half the viewport height, consistent with common editor conventions (vim, less, etc.), rather than jumping to the absolute bottom/top of the content.

https://claude.ai/code/session_01UmwxWovhZ9NNPYudacF9SS