### PR TITLE
Load missing dependency tasks for sidebar display

### DIFF
--- a/internal/tui/components/sidebar.go
+++ b/internal/tui/components/sidebar.go
@@ -468,11 +468,12 @@ func (s Sidebar) renderDependencies() string {
 	var lines []string
 	lines = append(lines, s.styles.Label.Underline(true).Render("Dependencies"))
 
+	var completedLines []string
 	for _, uuid := range s.task.Depends {
 		depTask := s.findTaskByUUID(uuid)
 		if depTask != nil {
 			if depTask.Status == "completed" {
-				lines = append(lines, fmt.Sprintf("  ✓ %s", depTask.Description))
+				completedLines = append(completedLines, fmt.Sprintf("  ✓ %s", depTask.Description))
 			} else {
 				lines = append(lines, fmt.Sprintf("  ○ #%d: %s", depTask.ID, depTask.Description))
 			}
@@ -484,6 +485,7 @@ func (s Sidebar) renderDependencies() string {
 			lines = append(lines, fmt.Sprintf("  ○ %s", shortUUID))
 		}
 	}
+	lines = append(lines, completedLines...)
 
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/components/sidebar_test.go
+++ b/internal/tui/components/sidebar_test.go
@@ -624,6 +624,16 @@ func TestCompletedDependencyDisplay(t *testing.T) {
 		t.Error("Expected pending dependency to show with ID")
 	}
 
+	// Verify completed dependencies appear after pending ones
+	pendingIdx := strings.Index(view, "Pending dependency task")
+	completedIdx := strings.Index(view, "Completed dependency task")
+	if pendingIdx == -1 || completedIdx == -1 {
+		t.Fatal("Expected both pending and completed dependency to be in view")
+	}
+	if completedIdx < pendingIdx {
+		t.Error("Expected completed dependencies to appear after pending ones")
+	}
+
 	// Verify the "Blocked by" label is present
 	if !strings.Contains(view, "Blocked by:") {
 		t.Error("Expected 'Blocked by:' label in view")

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -62,3 +62,9 @@ type AutocompleteDataLoadedMsg struct {
 	Tags     []string
 	Err      error
 }
+
+// DepTasksLoadedMsg is sent when dependency tasks (not in the main task list) have been loaded
+type DepTasksLoadedMsg struct {
+	Tasks []core.Task
+	Err   error
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -121,6 +121,7 @@ type Model struct {
 
 	// Task data
 	tasks            []core.Task
+	depTasks         []core.Task          // Dependency tasks not in the main task list (e.g., completed deps)
 	currentSection   *core.Section
 	projectSummaries []core.ProjectSummary // Project summaries for Projects tab
 
@@ -410,6 +411,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.tasks = msg.Tasks
+		m.depTasks = nil // Reset cached dependency tasks on reload
 		m.errorMessage = ""
 
 		// Note: Projects/tags for autocompletion are loaded separately via AutocompleteDataLoadedMsg
@@ -424,7 +426,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// For Projects view, load summaries to get completion percentages
 				// We'll build groups when summaries arrive
 				m.isLoading = true
-				return m, loadProjectSummaryCmd(m.service)
+				depCmd := loadMissingDepTasksCmd(m.service, m.tasks)
+				return m, tea.Batch(loadProjectSummaryCmd(m.service), depCmd)
 			} else if m.sections.IsTagsView() {
 				m.groups = core.GroupByTag(m.tasks)
 				// Show group list in the task list component
@@ -450,6 +453,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateSidebar()
 		}
 
+		// Load dependency tasks that aren't in the current task list
+		return m, loadMissingDepTasksCmd(m.service, m.tasks)
+
+	case DepTasksLoadedMsg:
+		if msg.Err == nil && len(msg.Tasks) > 0 {
+			m.depTasks = msg.Tasks
+			// Merge main tasks and dependency tasks for sidebar lookups
+			merged := make([]core.Task, 0, len(m.tasks)+len(m.depTasks))
+			merged = append(merged, m.tasks...)
+			merged = append(merged, m.depTasks...)
+			m.sidebar.SetAllTasks(merged)
+		}
 		return m, nil
 
 	case ProjectSummaryLoadedMsg:
@@ -2206,6 +2221,47 @@ func loadTasksCmd(service core.TaskService, filter string, isSearchTab bool) tea
 			Tasks: tasks,
 			Err:   err,
 		}
+	}
+}
+
+// loadMissingDepTasksCmd collects dependency UUIDs not present in the current
+// task list and loads them so the sidebar can display their descriptions.
+func loadMissingDepTasksCmd(service core.TaskService, tasks []core.Task) tea.Cmd {
+	// Build set of known UUIDs
+	known := make(map[string]struct{}, len(tasks))
+	for _, t := range tasks {
+		known[t.UUID] = struct{}{}
+	}
+
+	// Collect missing dependency UUIDs
+	missing := make(map[string]struct{})
+	for _, t := range tasks {
+		for _, dep := range t.Depends {
+			if _, ok := known[dep]; !ok {
+				missing[dep] = struct{}{}
+			}
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Build a filter to fetch all missing deps in one call
+	var parts []string
+	for uuid := range missing {
+		parts = append(parts, uuid)
+	}
+
+	return func() tea.Msg {
+		var allTasks []core.Task
+		for _, uuid := range parts {
+			fetched, err := service.Export(uuid)
+			if err == nil {
+				allTasks = append(allTasks, fetched...)
+			}
+		}
+		return DepTasksLoadedMsg{Tasks: allTasks}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -329,3 +329,48 @@ func TestInitWithSearchFilterWithStatus(t *testing.T) {
 		t.Errorf("Expected filter 'status:completed due:today' to be used, got '%s'", filterCalled)
 	}
 }
+
+func TestLoadMissingDepTasksCmd(t *testing.T) {
+	t.Run("returns nil when no missing deps", func(t *testing.T) {
+		tasks := []core.Task{
+			{UUID: "aaa", Depends: []string{"bbb"}},
+			{UUID: "bbb", Description: "Already loaded"},
+		}
+		service := &core.MockTaskService{}
+		cmd := loadMissingDepTasksCmd(service, tasks)
+		if cmd != nil {
+			t.Error("Expected nil command when all deps are present")
+		}
+	})
+
+	t.Run("loads missing dependency tasks", func(t *testing.T) {
+		tasks := []core.Task{
+			{UUID: "aaa", Depends: []string{"completed-uuid"}},
+		}
+		service := &core.MockTaskService{
+			ExportFunc: func(filter string) ([]core.Task, error) {
+				if filter == "completed-uuid" {
+					return []core.Task{
+						{UUID: "completed-uuid", Description: "Completed dep", Status: "completed"},
+					}, nil
+				}
+				return nil, nil
+			},
+		}
+		cmd := loadMissingDepTasksCmd(service, tasks)
+		if cmd == nil {
+			t.Fatal("Expected command for missing deps")
+		}
+		msg := cmd()
+		depMsg, ok := msg.(DepTasksLoadedMsg)
+		if !ok {
+			t.Fatalf("Expected DepTasksLoadedMsg, got %T", msg)
+		}
+		if len(depMsg.Tasks) != 1 {
+			t.Fatalf("Expected 1 dep task, got %d", len(depMsg.Tasks))
+		}
+		if depMsg.Tasks[0].Description != "Completed dep" {
+			t.Errorf("Expected description 'Completed dep', got '%s'", depMsg.Tasks[0].Description)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
This PR adds support for loading dependency tasks that are not present in the main task list (e.g., completed dependencies) so they can be displayed in the sidebar with their descriptions.

## Key Changes
- Added `depTasks` field to the Model to cache dependency tasks not in the main task list
- Created `loadMissingDepTasksCmd()` function that:
  - Identifies dependency UUIDs referenced by tasks but not present in the current task list
  - Fetches these missing dependencies asynchronously
  - Returns them via a new `DepTasksLoadedMsg` message
- Added `DepTasksLoadedMsg` message type to handle loaded dependency tasks
- Updated the Update() method to:
  - Reset cached dependency tasks when the main task list is reloaded
  - Load missing dependencies when switching to Projects view
  - Merge main tasks and dependency tasks before updating the sidebar for complete task lookups
- Added comprehensive tests for the `loadMissingDepTasksCmd()` function covering both cases where all dependencies are present and where some are missing

## Implementation Details
- The function builds a set of known task UUIDs from the main task list, then identifies any dependencies not in that set
- Missing dependencies are fetched individually via the service's Export() method
- The sidebar's task list is updated with the merged set of main and dependency tasks to enable proper description lookups
- Returns nil command when there are no missing dependencies to avoid unnecessary async operations

https://claude.ai/code/session_015yj4weXnrH5nMTdMYFwd1w