### PR TITLE
feat: add REST API server to expose TaskService over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#features-at-a-glance">Features</a> &bull;
   <a href="#configuration">Configuration</a> &bull;
-  <a href="#google-calendar-sync">Calendar Sync</a>
+  <a href="#google-calendar-sync">Calendar Sync</a> &bull;
+  <a href="#api-server">API Server</a>
 </p>
 
 ---
@@ -30,6 +31,7 @@ That's it. Press `?` for help.
 - **Batch operations** &mdash; select multiple tasks with `Space`, then act on all of them at once
 - **Custom commands** &mdash; wire up any key to run a shell command with task data (`xdg-open {{.url}}`, copy to clipboard, git clone, etc.)
 - **Google Calendar sync** &mdash; push tasks to your calendar with `wui sync`
+- **REST API server** &mdash; run `wui serve` to expose the Taskwarrior backend over HTTP for Flutter, web, or any other client
 - **Fully configurable** &mdash; tabs, columns, keybindings, themes, sort order &mdash; your workflow, your rules
 - **Respects your `.taskrc`** &mdash; reads your existing Taskwarrior contexts and settings
 
@@ -90,6 +92,9 @@ wui --search "project:Home +urgent"
 
 # Sync tasks to Google Calendar
 wui sync
+
+# Start the REST API server (default: localhost:7007)
+wui serve
 
 # Show version
 wui version
@@ -426,14 +431,20 @@ On first run, you'll authorize via browser. The token is saved to `~/.config/wui
 wui                              Launch the TUI
 wui version                      Print version info
 wui sync                         Sync tasks to Google Calendar
+wui serve                        Start the REST API server
 
-Flags:
+Flags (all commands):
   --config string                Config file path (default: ~/.config/wui/config.yaml)
   --taskrc string                Taskrc file path (default: ~/.taskrc)
   --task-bin string              Task binary path (default: /usr/local/bin/task)
-  --search string                Open in Search tab with a pre-applied filter
   --log-level string             Log level: debug, info, warn, error (default: error)
   --log-format string            Log format: text, json (default: text)
+
+wui flags:
+  --search string                Open in Search tab with a pre-applied filter
+
+wui serve flags:
+  --addr string                  Address to listen on (default: localhost:7007)
 ```
 
 ### Logging
@@ -466,6 +477,105 @@ wui is inspired by [taskwarrior-tui](https://github.com/kdheepak/taskwarrior-tui
 | Multi-select | Batch operations on selected tasks | &mdash; |
 | Markdown export | Copy tasks to clipboard | &mdash; |
 | Short view | Auto-adapts to narrow terminals | &mdash; |
+
+## API Server
+
+`wui serve` starts a lightweight REST/JSON HTTP server backed by the same Taskwarrior client that the TUI uses. This lets any HTTP-capable client — Flutter, a web app, scripts, other terminals — drive the same business logic without running the TUI.
+
+```bash
+# Listen on localhost only (default)
+wui serve
+
+# Listen on all interfaces (e.g. to reach from a phone on the same network)
+wui serve --addr :7007
+```
+
+The server shuts down cleanly on `Ctrl+C`.
+
+### Endpoints
+
+All paths are under `/api/v1`. Requests and responses use JSON.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/tasks` | List tasks. Optional `?filter=` query param uses Taskwarrior filter syntax. |
+| `POST` | `/api/v1/tasks` | Create a task. Body: `{"description": "Buy milk +shopping"}` |
+| `PUT` | `/api/v1/tasks/{uuid}` | Modify a task. Body: `{"modifications": "priority:H due:tomorrow"}` |
+| `DELETE` | `/api/v1/tasks/{uuid}` | Delete a task. |
+| `POST` | `/api/v1/tasks/{uuid}/done` | Mark a task done. |
+| `POST` | `/api/v1/tasks/{uuid}/start` | Start a task. |
+| `POST` | `/api/v1/tasks/{uuid}/stop` | Stop a task. |
+| `POST` | `/api/v1/tasks/{uuid}/annotate` | Add an annotation. Body: `{"text": "See ticket #42"}` |
+| `POST` | `/api/v1/undo` | Undo the last Taskwarrior operation. |
+| `GET` | `/api/v1/projects` | List project summaries with completion percentages. |
+
+### Quick Examples
+
+```bash
+# List pending tasks in a project
+curl "http://localhost:7007/api/v1/tasks?filter=project:Home+status:pending"
+
+# Add a task
+curl -X POST http://localhost:7007/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Fix the leak +home"}'
+
+# Mark a task done
+curl -X POST http://localhost:7007/api/v1/tasks/<uuid>/done
+
+# Modify priority and due date
+curl -X PUT http://localhost:7007/api/v1/tasks/<uuid> \
+  -H "Content-Type: application/json" \
+  -d '{"modifications": "priority:H due:friday"}'
+```
+
+### Response Format
+
+`GET /api/v1/tasks` returns a JSON array of task objects. All date fields use RFC 3339 (UTC):
+
+```json
+[
+  {
+    "id": 1,
+    "uuid": "a1b2c3d4-...",
+    "description": "Fix the leak",
+    "project": "Home",
+    "tags": ["home"],
+    "priority": "H",
+    "status": "pending",
+    "due": "2026-05-15T00:00:00Z",
+    "entry": "2026-05-10T08:00:00Z",
+    "urgency": 8.5,
+    "annotations": [
+      { "entry": "2026-05-10T09:00:00Z", "description": "Called plumber" }
+    ]
+  }
+]
+```
+
+### Using from Flutter
+
+Add the `http` package to your Flutter project and point it at `wui serve`:
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+const base = 'http://localhost:7007/api/v1';
+
+Future<List<dynamic>> fetchTasks({String filter = ''}) async {
+  final uri = Uri.parse('$base/tasks').replace(
+    queryParameters: filter.isNotEmpty ? {'filter': filter} : null,
+  );
+  final res = await http.get(uri);
+  return jsonDecode(res.body) as List<dynamic>;
+}
+
+Future<void> completeTask(String uuid) =>
+    http.post(Uri.parse('$base/tasks/$uuid/done'));
+```
+
+> **Security note:** The server has no built-in authentication. Run it on `localhost` (the default) or inside a trusted network. Do not expose it directly to the internet.
 
 ## Development
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/clobrano/wui/internal/core"
+)
+
+// handlers holds the TaskService and provides HTTP handler methods.
+type handlers struct {
+	svc core.TaskService
+}
+
+// writeJSON encodes v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to encode JSON response", "error", err)
+	}
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, ErrorResponse{Error: msg})
+}
+
+// listTasks handles GET /api/v1/tasks?filter=<filter>
+func (h *handlers) listTasks(w http.ResponseWriter, r *http.Request) {
+	filter := r.URL.Query().Get("filter")
+	tasks, err := h.svc.Export(filter)
+	if err != nil {
+		slog.Error("Export failed", "filter", filter, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	dtos := make([]TaskDTO, len(tasks))
+	for i, t := range tasks {
+		dtos[i] = taskToDTO(t)
+	}
+	writeJSON(w, http.StatusOK, dtos)
+}
+
+// addTask handles POST /api/v1/tasks
+func (h *handlers) addTask(w http.ResponseWriter, r *http.Request) {
+	var req AddTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Description) == "" {
+		writeError(w, http.StatusBadRequest, "description is required")
+		return
+	}
+
+	uuid, err := h.svc.Add(req.Description)
+	if err != nil {
+		slog.Error("Add task failed", "description", req.Description, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, AddTaskResponse{UUID: uuid})
+}
+
+// modifyTask handles PUT /api/v1/tasks/{uuid}
+func (h *handlers) modifyTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	var req ModifyTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Modifications) == "" {
+		writeError(w, http.StatusBadRequest, "modifications is required")
+		return
+	}
+
+	if err := h.svc.Modify(uuid, req.Modifications); err != nil {
+		slog.Error("Modify task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// annotateTask handles POST /api/v1/tasks/{uuid}/annotate
+func (h *handlers) annotateTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	var req AnnotateTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Text) == "" {
+		writeError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+
+	if err := h.svc.Annotate(uuid, req.Text); err != nil {
+		slog.Error("Annotate task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// doneTask handles POST /api/v1/tasks/{uuid}/done
+func (h *handlers) doneTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	if err := h.svc.Done(uuid); err != nil {
+		slog.Error("Done task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteTask handles DELETE /api/v1/tasks/{uuid}
+func (h *handlers) deleteTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	if err := h.svc.Delete(uuid); err != nil {
+		slog.Error("Delete task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// startTask handles POST /api/v1/tasks/{uuid}/start
+func (h *handlers) startTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	if err := h.svc.Start(uuid); err != nil {
+		slog.Error("Start task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// stopTask handles POST /api/v1/tasks/{uuid}/stop
+func (h *handlers) stopTask(w http.ResponseWriter, r *http.Request) {
+	uuid := r.PathValue("uuid")
+	if uuid == "" {
+		writeError(w, http.StatusBadRequest, "uuid is required")
+		return
+	}
+
+	if err := h.svc.Stop(uuid); err != nil {
+		slog.Error("Stop task failed", "uuid", uuid, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// undoLast handles POST /api/v1/undo
+func (h *handlers) undoLast(w http.ResponseWriter, r *http.Request) {
+	if err := h.svc.Undo(); err != nil {
+		slog.Error("Undo failed", "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// listProjects handles GET /api/v1/projects
+func (h *handlers) listProjects(w http.ResponseWriter, r *http.Request) {
+	summaries, err := h.svc.GetProjectSummary()
+	if err != nil {
+		slog.Error("GetProjectSummary failed", "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	dtos := make([]ProjectSummaryDTO, len(summaries))
+	for i, s := range summaries {
+		dtos[i] = projectSummaryToDTO(s)
+	}
+	writeJSON(w, http.StatusOK, dtos)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,82 @@
+// Package api provides a REST/JSON HTTP server that exposes the core.TaskService
+// interface over the network. This allows any HTTP client — Flutter, web, CLI tools —
+// to drive the same business logic that the TUI uses locally.
+//
+// API base path: /api/v1
+//
+//	GET    /api/v1/tasks               list tasks (optional ?filter= query param)
+//	POST   /api/v1/tasks               create a task
+//	PUT    /api/v1/tasks/{uuid}         modify a task
+//	DELETE /api/v1/tasks/{uuid}         delete a task
+//	POST   /api/v1/tasks/{uuid}/done    mark a task done
+//	POST   /api/v1/tasks/{uuid}/start   start a task
+//	POST   /api/v1/tasks/{uuid}/stop    stop a task
+//	POST   /api/v1/tasks/{uuid}/annotate add an annotation
+//	POST   /api/v1/undo                undo last operation
+//	GET    /api/v1/projects            list project summaries
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/clobrano/wui/internal/core"
+)
+
+// Server is the HTTP API server.
+type Server struct {
+	httpServer *http.Server
+}
+
+// NewServer creates a new Server that wraps the given TaskService and listens on addr.
+// addr format: "host:port", e.g. "localhost:7007" or ":7007".
+func NewServer(svc core.TaskService, addr string) *Server {
+	h := &handlers{svc: svc}
+
+	mux := http.NewServeMux()
+	registerRoutes(mux, h)
+
+	return &Server{
+		httpServer: &http.Server{
+			Addr:         addr,
+			Handler:      mux,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		},
+	}
+}
+
+// registerRoutes wires all API endpoints into the mux.
+// Uses Go 1.22+ pattern matching: "METHOD /path/{param}".
+func registerRoutes(mux *http.ServeMux, h *handlers) {
+	mux.HandleFunc("GET /api/v1/tasks", h.listTasks)
+	mux.HandleFunc("POST /api/v1/tasks", h.addTask)
+	mux.HandleFunc("PUT /api/v1/tasks/{uuid}", h.modifyTask)
+	mux.HandleFunc("DELETE /api/v1/tasks/{uuid}", h.deleteTask)
+	mux.HandleFunc("POST /api/v1/tasks/{uuid}/done", h.doneTask)
+	mux.HandleFunc("POST /api/v1/tasks/{uuid}/start", h.startTask)
+	mux.HandleFunc("POST /api/v1/tasks/{uuid}/stop", h.stopTask)
+	mux.HandleFunc("POST /api/v1/tasks/{uuid}/annotate", h.annotateTask)
+	mux.HandleFunc("POST /api/v1/undo", h.undoLast)
+	mux.HandleFunc("GET /api/v1/projects", h.listProjects)
+}
+
+// Start begins listening and serving requests. It blocks until the server stops.
+func (s *Server) Start() error {
+	slog.Info("API server listening", "addr", s.httpServer.Addr)
+	fmt.Printf("wui API server listening on %s\n", s.httpServer.Addr)
+	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("server error: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the server within the given timeout.
+func (s *Server) Shutdown(ctx context.Context) error {
+	slog.Info("Shutting down API server")
+	return s.httpServer.Shutdown(ctx)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"time"
+
+	"github.com/clobrano/wui/internal/core"
+)
+
+// TaskDTO is the JSON representation of a core.Task for the REST API.
+// Time fields use RFC3339 strings so any client (Flutter, web, etc.) can parse them easily.
+type TaskDTO struct {
+	ID          int              `json:"id"`
+	UUID        string           `json:"uuid"`
+	Description string           `json:"description"`
+	Project     string           `json:"project,omitempty"`
+	Tags        []string         `json:"tags,omitempty"`
+	Priority    string           `json:"priority,omitempty"`
+	Status      string           `json:"status"`
+	Due         *string          `json:"due,omitempty"`
+	Scheduled   *string          `json:"scheduled,omitempty"`
+	Wait        *string          `json:"wait,omitempty"`
+	Start       *string          `json:"start,omitempty"`
+	Entry       string           `json:"entry"`
+	Modified    *string          `json:"modified,omitempty"`
+	End         *string          `json:"end,omitempty"`
+	Depends     []string         `json:"depends,omitempty"`
+	Annotations []AnnotationDTO  `json:"annotations,omitempty"`
+	UDAs        map[string]string `json:"udas,omitempty"`
+	Urgency     float64          `json:"urgency"`
+}
+
+// AnnotationDTO is the JSON representation of a core.Annotation.
+type AnnotationDTO struct {
+	Entry       string `json:"entry"`
+	Description string `json:"description"`
+}
+
+// ProjectSummaryDTO is the JSON representation of a core.ProjectSummary.
+type ProjectSummaryDTO struct {
+	Name       string `json:"name"`
+	Percentage int    `json:"percentage"`
+}
+
+// AddTaskRequest is the body for POST /api/v1/tasks.
+type AddTaskRequest struct {
+	Description string `json:"description"`
+}
+
+// AddTaskResponse is the response for POST /api/v1/tasks.
+type AddTaskResponse struct {
+	UUID string `json:"uuid"`
+}
+
+// ModifyTaskRequest is the body for PUT /api/v1/tasks/{uuid}.
+// Modifications use Taskwarrior syntax, e.g. "priority:H due:tomorrow +urgent".
+type ModifyTaskRequest struct {
+	Modifications string `json:"modifications"`
+}
+
+// AnnotateTaskRequest is the body for POST /api/v1/tasks/{uuid}/annotate.
+type AnnotateTaskRequest struct {
+	Text string `json:"text"`
+}
+
+// ErrorResponse is returned for all error cases.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// taskToDTO converts a core.Task to a TaskDTO.
+func taskToDTO(t core.Task) TaskDTO {
+	dto := TaskDTO{
+		ID:          t.ID,
+		UUID:        t.UUID,
+		Description: t.Description,
+		Project:     t.Project,
+		Tags:        t.Tags,
+		Priority:    t.Priority,
+		Status:      t.Status,
+		Depends:     t.Depends,
+		UDAs:        t.UDAs,
+		Urgency:     t.Urgency,
+		Entry:       t.Entry.UTC().Format(time.RFC3339),
+	}
+
+	dto.Due = formatTimePtr(t.Due)
+	dto.Scheduled = formatTimePtr(t.Scheduled)
+	dto.Wait = formatTimePtr(t.Wait)
+	dto.Start = formatTimePtr(t.Start)
+	dto.Modified = formatTimePtr(t.Modified)
+	dto.End = formatTimePtr(t.End)
+
+	if len(t.Annotations) > 0 {
+		dto.Annotations = make([]AnnotationDTO, len(t.Annotations))
+		for i, a := range t.Annotations {
+			dto.Annotations[i] = AnnotationDTO{
+				Entry:       a.Entry.UTC().Format(time.RFC3339),
+				Description: a.Description,
+			}
+		}
+	}
+
+	return dto
+}
+
+func formatTimePtr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339)
+	return &s
+}
+
+// projectSummaryToDTO converts a core.ProjectSummary to a ProjectSummaryDTO.
+func projectSummaryToDTO(p core.ProjectSummary) ProjectSummaryDTO {
+	return ProjectSummaryDTO{
+		Name:       p.Name,
+		Percentage: p.Percentage,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,11 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
 
+	"github.com/clobrano/wui/internal/api"
 	"github.com/clobrano/wui/internal/calendar"
 	"github.com/clobrano/wui/internal/config"
 	"github.com/clobrano/wui/internal/taskwarrior"
@@ -51,6 +55,41 @@ var (
 	syncTaskFilter   string
 )
 
+var serveAddr string
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the REST API server",
+	Long: `Start the wui REST/JSON API server.
+
+The server exposes the Taskwarrior backend over HTTP so that alternative UIs
+(Flutter, web, CLI scripts) can drive the same business logic as the TUI.
+
+API base: http://<addr>/api/v1
+
+Endpoints:
+  GET    /api/v1/tasks               list tasks (optional ?filter= query param)
+  POST   /api/v1/tasks               create a task  {"description":"..."}
+  PUT    /api/v1/tasks/{uuid}         modify a task  {"modifications":"priority:H"}
+  DELETE /api/v1/tasks/{uuid}         delete a task
+  POST   /api/v1/tasks/{uuid}/done    mark done
+  POST   /api/v1/tasks/{uuid}/start   start
+  POST   /api/v1/tasks/{uuid}/stop    stop
+  POST   /api/v1/tasks/{uuid}/annotate add annotation  {"text":"..."}
+  POST   /api/v1/undo                undo last operation
+  GET    /api/v1/projects            list project summaries
+
+Examples:
+  wui serve                    # Listen on localhost:7007
+  wui serve --addr :7007       # Listen on all interfaces`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runServe(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 var syncCmd = &cobra.Command{
 	Use:   "sync",
 	Short: "Sync Taskwarrior tasks to Google Calendar",
@@ -85,6 +124,10 @@ func init() {
 	// Add subcommands
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(syncCmd)
+	rootCmd.AddCommand(serveCmd)
+
+	// Serve command flags
+	serveCmd.Flags().StringVar(&serveAddr, "addr", "localhost:7007", "address to listen on (host:port)")
 
 	// Sync command flags (optional - override config file values)
 	syncCmd.Flags().StringVar(&syncCalendarName, "calendar", "", "Google Calendar name (overrides config)")
@@ -263,6 +306,62 @@ Visit https://taskwarrior.org for more information.`, err)
 
 	slog.Debug("Task binary found", "path", path)
 	return nil
+}
+
+// runServe starts the REST API server backed by the local Taskwarrior installation.
+func runServe() error {
+	cfgPath := config.ResolveConfigPath(configPath)
+	if err := config.ValidateExplicitConfigPath(configPath, cfgPath); err != nil {
+		return err
+	}
+
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		initLogging(nil)
+		slog.Error("Failed to load config", "error", err, "path", cfgPath)
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	initLogging(cfg)
+	slog.Info("Starting wui API server", "version", version.GetVersion())
+
+	if taskBinPath != "" {
+		cfg.TaskBin = taskBinPath
+	}
+	if taskrcPath != "" {
+		cfg.TaskrcPath = taskrcPath
+	}
+
+	if err := checkTaskBinary(cfg.TaskBin); err != nil {
+		return err
+	}
+	if err := config.ValidateTaskrcPath(cfg.TaskrcPath); err != nil {
+		return err
+	}
+
+	client, err := taskwarrior.NewClient(cfg.TaskBin, cfg.TaskrcPath)
+	if err != nil {
+		return fmt.Errorf("failed to create taskwarrior client: %w", err)
+	}
+
+	srv := api.NewServer(client, serveAddr)
+
+	// Graceful shutdown on SIGINT / SIGTERM
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-stop:
+		fmt.Println("\nShutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return srv.Shutdown(ctx)
+	}
 }
 
 // runSync performs the Google Calendar sync operation


### PR DESCRIPTION
Introduces internal/api with a lightweight HTTP server that wraps the
existing core.TaskService interface, making the Taskwarrior backend
reachable by any HTTP client (Flutter, web, CLI scripts) without
requiring the TUI.

New package internal/api:
- server.go  – Server lifecycle (NewServer, Start, Shutdown)
- handlers.go – HTTP handlers for every TaskService method
- types.go   – JSON DTOs mapping core.Task ↔ HTTP request/response

New CLI subcommand:
  wui serve [--addr localhost:7007]

REST endpoints at /api/v1:
  GET    /tasks               export tasks (?filter= query param)
  POST   /tasks               add a task
  PUT    /tasks/{uuid}         modify a task
  DELETE /tasks/{uuid}         delete a task
  POST   /tasks/{uuid}/done    mark done
  POST   /tasks/{uuid}/start   start
  POST   /tasks/{uuid}/stop    stop
  POST   /tasks/{uuid}/annotate annotate
  POST   /undo                undo last operation
  GET    /projects            list project summaries

No new dependencies — uses only Go stdlib net/http and the packages
already in go.mod. The TUI continues to work as before; serve is an
additive subcommand.

https://claude.ai/code/session_01RcRKJt1fn3v4SFwmCUS9WJ