### PR TITLE
Add TODO annotation quick action with 't' keybinding

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -136,6 +136,7 @@ func DefaultKeybindings() map[string]string {
 		"edit":     "e",
 		"modify":   "m",
 		"annotate": "a",
+		"todo":     "t",
 		"new":      "n",
 		"undo":     "u",
 		"open_url": "o",
@@ -179,6 +180,7 @@ func GetInternalShortcuts(keybindings map[string]string) map[string]string {
 	shortcuts[getKey("edit", "e")] = "edit"
 	shortcuts[getKey("modify", "m")] = "modify"
 	shortcuts[getKey("annotate", "a")] = "annotate"
+	shortcuts[getKey("todo", "t")] = "add TODO annotation"
 	shortcuts[getKey("new", "n")] = "new task"
 	shortcuts[getKey("undo", "u")] = "undo"
 	shortcuts[getKey("open_url", "o")] = "open URL/file from annotation"

--- a/internal/tui/components/help.go
+++ b/internal/tui/components/help.go
@@ -276,6 +276,7 @@ func keybindingGroupsFromConfig(keybindings map[string]string) []KeybindingGroup
 				{Keys: []string{getKey("modify", "m")}, Description: "Modify task(s) (quick edit)"},
 				{Keys: []string{"M"}, Description: "Export task(s) as markdown (to clipboard)"},
 				{Keys: []string{getKey("annotate", "a")}, Description: "Add annotation to task(s)"},
+				{Keys: []string{getKey("todo", "t")}, Description: "Add TODO annotation to task(s)"},
 				{Keys: []string{getKey("open_url", "o")}, Description: "Open URL from annotations"},
 				{Keys: []string{getKey("undo", "u")}, Description: "Undo last operation"},
 			},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1508,6 +1508,18 @@ func (m Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.keyMatches(keyPressed, "todo") {
+		// Add TODO annotation to task(s)
+		selectedTasks := m.taskList.GetSelectedTasks()
+		if len(selectedTasks) > 0 {
+			m.state = StateAnnotateInput
+			m.annotateInput.SetValue("TODO: ")
+			m.updateComponentSizes()
+			return m, m.annotateInput.Focus()
+		}
+		return m, nil
+	}
+
 	if m.keyMatches(keyPressed, "open_url") {
 		// Open URL or file from task annotations
 		if !m.inGroupView {


### PR DESCRIPTION
## Summary
This PR adds a new quick action to annotate selected tasks with a "TODO: " prefix, accessible via the 't' keybinding in normal mode.

## Key Changes
- **Model Handler**: Added `handleNormalKeys` logic to detect the "todo" keybinding and transition to annotation input mode with "TODO: " pre-filled
- **Default Keybindings**: Registered "todo" action with 't' as the default keybinding in `DefaultKeybindings()`
- **Internal Shortcuts**: Added "todo" → "add TODO annotation" mapping to `GetInternalShortcuts()` for help text display
- **Help Documentation**: Updated the help panel to display the new "Add TODO annotation to task(s)" action with its keybinding

## Implementation Details
The implementation follows the existing annotation pattern:
- Requires one or more selected tasks to activate
- Transitions to `StateAnnotateInput` mode
- Pre-populates the annotation input with "TODO: " text
- Focuses the annotation input for immediate user input
- Returns early if no tasks are selected

https://claude.ai/code/session_01MzwGL9WYwqNZF2oE1xxj7F