### PR TITLE
Allow Enter key to exit task detail views

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1256,7 +1256,7 @@ func (m Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// In task detail view, handle detail-specific keys
 	if m.viewMode == ViewModeTaskDetail {
 		switch keyPressed {
-		case "esc":
+		case "esc", "enter":
 			m.viewMode = ViewModeList
 			m.updateComponentSizes()
 			return m, nil
@@ -1312,6 +1312,20 @@ func (m Model) handleNormalKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.taskList.ToggleSelection()
 		}
 		return m, nil
+	}
+
+	// Enter key to return from task detail views
+	if keyPressed == "enter" {
+		if m.viewMode == ViewModeSmallTaskDetail {
+			m.viewMode = ViewModeSmall
+			m.updateComponentSizes()
+			return m, nil
+		}
+		if m.viewMode == ViewModeTaskDetail {
+			m.viewMode = ViewModeList
+			m.updateComponentSizes()
+			return m, nil
+		}
 	}
 
 	// Escape key for clearing selections/going back (not configurable)


### PR DESCRIPTION
## Summary
Added support for the Enter key as an alternative to Escape for exiting task detail views, improving user experience by providing a more intuitive navigation option.

## Key Changes
- Modified task detail view exit handler to accept both "esc" and "enter" keys in `ViewModeTaskDetail`
- Added dedicated Enter key handler for exiting both `ViewModeTaskDetail` and `ViewModeSmallTaskDetail` views
- Both key presses now properly trigger `updateComponentSizes()` to refresh the UI layout when returning to the previous view

## Implementation Details
The change introduces a new conditional block that checks for the Enter key and handles navigation back from detail views before the existing Escape key handler. This allows users to press Enter to dismiss the task detail view and return to either the task list (from full detail view) or small task list (from small detail view), making the navigation feel more natural and consistent with common UI patterns.

https://claude.ai/code/session_014GexVSEyVwEC7L7MTNWAaD