### PR TITLE
Initialize Percentage field in TaskGroup structs

### DIFF
--- a/internal/core/grouping.go
+++ b/internal/core/grouping.go
@@ -101,9 +101,10 @@ func GroupByProject(tasks []Task) []TaskGroup {
 	var groups []TaskGroup
 	for projectName, projectTasks := range projectMap {
 		groups = append(groups, TaskGroup{
-			Name:  projectName,
-			Count: len(projectTasks),
-			Tasks: projectTasks,
+			Name:       projectName,
+			Count:      len(projectTasks),
+			Tasks:      projectTasks,
+			Percentage: -1,
 		})
 	}
 
@@ -147,9 +148,10 @@ func GroupByTag(tasks []Task) []TaskGroup {
 	var groups []TaskGroup
 	for tagName, tagTasks := range tagMap {
 		groups = append(groups, TaskGroup{
-			Name:  tagName,
-			Count: len(tagTasks),
-			Tasks: tagTasks,
+			Name:       tagName,
+			Count:      len(tagTasks),
+			Tasks:      tagTasks,
+			Percentage: -1,
 		})
 	}
 


### PR DESCRIPTION
## Summary
Updated the `GroupByProject` and `GroupByTag` functions to initialize the `Percentage` field when creating `TaskGroup` structs. This ensures the field is explicitly set rather than relying on zero-value initialization.

## Changes
- Added `Percentage: -1` initialization in `GroupByProject` function when creating TaskGroup instances
- Added `Percentage: -1` initialization in `GroupByTag` function when creating TaskGroup instances
- Aligned struct field formatting for improved readability in both functions

## Implementation Details
The `Percentage` field is initialized to `-1` in both grouping functions, which likely serves as a sentinel value indicating that the percentage has not yet been calculated. This explicit initialization makes the intent clearer and ensures consistent behavior across all TaskGroup creation paths.

https://claude.ai/code/session_01Lg8t7KbbcrNAiYcbLT4JZE