### PR TITLE
Add support for task duration UDA in calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,12 +418,20 @@ On first run, you'll authorize via browser. The token is saved to `~/.config/wui
 
 ### How it works
 
-- Tasks become all-day events based on due date (or scheduled date as fallback)
+- Tasks with a due (or scheduled) date at midnight become all-day events; tasks with a specific time become timed events
+- Timed events use the `dur` UDA for their length (e.g. `dur:30min`, `dur:1h30min`); without it they default to 15 minutes
 - Events include UUID, project, tags, and status in the description
 - Completed tasks show a **✓** checkmark in the title
 - Events are color-coded by priority (red = high, yellow = medium)
 - Existing events are updated when tasks change
 - Sync is **one-way**: Taskwarrior → Google Calendar
+
+> **Tip:** `dur` is a User Defined Attribute. Define it once in your `.taskrc` to use it:
+> ```
+> uda.dur.type=duration
+> uda.dur.label=Duration
+> ```
+> Then set it on a task, e.g. `task add "Standup" due:2026-03-15T09:00 dur:15min`.
 
 ## CLI Reference
 

--- a/internal/calendar/duration.go
+++ b/internal/calendar/duration.go
@@ -1,0 +1,177 @@
+package calendar
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Nominal durations for calendar-oriented units. Months and years are
+// approximations, which is acceptable for sizing a calendar event block.
+const (
+	durDay   = 24 * time.Hour
+	durWeek  = 7 * durDay
+	durMonth = 30 * durDay
+	durYear  = 365 * durDay
+)
+
+// ParseTaskDuration parses a Taskwarrior duration value into a time.Duration.
+//
+// Taskwarrior exports duration-typed UDAs as ISO 8601 durations such as
+// "PT30M", "PT1H30M" or "P1DT2H". For robustness this also accepts common
+// shorthand ("30min", "1h30m", "2d") and a bare number (interpreted as
+// seconds, matching Taskwarrior's default unit).
+//
+// It returns an error if the value cannot be parsed. The returned duration may
+// be zero or negative; callers decide how to treat such values.
+func ParseTaskDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	if s[0] == 'P' || s[0] == 'p' {
+		return parseISO8601Duration(s)
+	}
+	return parseShorthandDuration(s)
+}
+
+// parseISO8601Duration parses the subset of ISO 8601 durations that Taskwarrior
+// emits: P[nY][nM][nD][T[nH][nM][nS]] and the week form P[nW].
+func parseISO8601Duration(s string) (time.Duration, error) {
+	rest := s[1:] // strip leading 'P'
+	if rest == "" {
+		return 0, fmt.Errorf("invalid ISO 8601 duration %q", s)
+	}
+
+	var total time.Duration
+	inTime := false
+	numStart := 0
+	sawField := false
+
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if c == 'T' || c == 't' {
+			inTime = true
+			numStart = i + 1
+			continue
+		}
+		if (c >= '0' && c <= '9') || c == '.' {
+			continue
+		}
+
+		numStr := rest[numStart:i]
+		if numStr == "" {
+			return 0, fmt.Errorf("invalid ISO 8601 duration %q: missing value before %q", s, string(c))
+		}
+		val, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid ISO 8601 duration %q: %w", s, err)
+		}
+
+		var unit time.Duration
+		switch c {
+		case 'Y', 'y':
+			unit = durYear
+		case 'W', 'w':
+			unit = durWeek
+		case 'D', 'd':
+			unit = durDay
+		case 'H', 'h':
+			unit = time.Hour
+		case 'S', 's':
+			unit = time.Second
+		case 'M', 'm':
+			// 'M' means minutes after the 'T' separator, months before it.
+			if inTime {
+				unit = time.Minute
+			} else {
+				unit = durMonth
+			}
+		default:
+			return 0, fmt.Errorf("invalid ISO 8601 duration %q: unknown unit %q", s, string(c))
+		}
+
+		total += time.Duration(val * float64(unit))
+		sawField = true
+		numStart = i + 1
+	}
+
+	if !sawField {
+		return 0, fmt.Errorf("invalid ISO 8601 duration %q: no fields", s)
+	}
+	return total, nil
+}
+
+// parseShorthandDuration parses human/Taskwarrior shorthand such as "30min",
+// "1h30m", "2d" or a bare number (seconds). It is a lenient fallback for values
+// that are not in ISO 8601 form.
+func parseShorthandDuration(s string) (time.Duration, error) {
+	s = strings.ToLower(s)
+
+	var total time.Duration
+	i := 0
+	sawField := false
+
+	for i < len(s) {
+		if s[i] == ' ' {
+			i++
+			continue
+		}
+
+		start := i
+		for i < len(s) && ((s[i] >= '0' && s[i] <= '9') || s[i] == '.') {
+			i++
+		}
+		if start == i {
+			return 0, fmt.Errorf("invalid duration %q", s)
+		}
+		numStr := s[start:i]
+
+		unitStart := i
+		for i < len(s) && s[i] >= 'a' && s[i] <= 'z' {
+			i++
+		}
+		unitStr := s[unitStart:i]
+
+		val, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		unit, err := shorthandUnit(unitStr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+
+		total += time.Duration(val * float64(unit))
+		sawField = true
+	}
+
+	if !sawField {
+		return 0, fmt.Errorf("invalid duration %q", s)
+	}
+	return total, nil
+}
+
+// shorthandUnit maps a shorthand unit suffix to its duration. An empty suffix
+// defaults to seconds, matching Taskwarrior's bare-number convention.
+func shorthandUnit(u string) (time.Duration, error) {
+	switch u {
+	case "", "s", "sec", "secs", "second", "seconds":
+		return time.Second, nil
+	case "m", "min", "mins", "minute", "minutes":
+		return time.Minute, nil
+	case "h", "hr", "hrs", "hour", "hours":
+		return time.Hour, nil
+	case "d", "day", "days":
+		return durDay, nil
+	case "w", "wk", "wks", "week", "weeks":
+		return durWeek, nil
+	case "mo", "mon", "month", "months":
+		return durMonth, nil
+	case "y", "yr", "yrs", "year", "years":
+		return durYear, nil
+	default:
+		return 0, fmt.Errorf("unknown duration unit %q", u)
+	}
+}

--- a/internal/calendar/duration_test.go
+++ b/internal/calendar/duration_test.go
@@ -1,0 +1,60 @@
+package calendar
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTaskDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		// ISO 8601 (what Taskwarrior exports for duration UDAs)
+		{"iso minutes", "PT30M", 30 * time.Minute, false},
+		{"iso hour", "PT1H", time.Hour, false},
+		{"iso hour minutes", "PT1H30M", 90 * time.Minute, false},
+		{"iso seconds", "PT45S", 45 * time.Second, false},
+		{"iso day", "P1D", 24 * time.Hour, false},
+		{"iso day and time", "P1DT2H", 26 * time.Hour, false},
+		{"iso week", "P1W", 7 * 24 * time.Hour, false},
+		{"iso month before T", "P1M", durMonth, false},
+		{"iso minute after T", "PT1M", time.Minute, false},
+		{"iso lowercase", "pt15m", 15 * time.Minute, false},
+
+		// Shorthand fallback
+		{"shorthand min", "30min", 30 * time.Minute, false},
+		{"shorthand h", "2h", 2 * time.Hour, false},
+		{"shorthand combined", "1h30m", 90 * time.Minute, false},
+		{"shorthand day", "2d", 48 * time.Hour, false},
+		{"shorthand week", "1w", 7 * 24 * time.Hour, false},
+		{"bare number is seconds", "90", 90 * time.Second, false},
+		{"shorthand spaces", "1h 30min", 90 * time.Minute, false},
+
+		// Errors
+		{"empty", "", 0, true},
+		{"garbage", "abc", 0, true},
+		{"unknown unit", "5z", 0, true},
+		{"iso missing value", "PTM", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTaskDuration(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTaskDuration(%q) expected error, got %v", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTaskDuration(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseTaskDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/calendar/sync.go
+++ b/internal/calendar/sync.go
@@ -351,8 +351,9 @@ func (s *SyncClient) taskToEvent(task core.Task) *calendar.Event {
 		event.Start = &calendar.EventDateTime{
 			DateTime: eventTime.Format(time.RFC3339),
 		}
-		// Default to 15 minutes duration for timed events
-		endTime := eventTime.Add(15 * time.Minute)
+		// Duration comes from the 'dur' UDA when set and valid, otherwise
+		// falls back to the default duration.
+		endTime := eventTime.Add(eventDuration(task))
 		event.End = &calendar.EventDateTime{
 			DateTime: endTime.Format(time.RFC3339),
 		}
@@ -425,6 +426,27 @@ func (s *SyncClient) taskToEvent(task core.Task) *calendar.Event {
 	return event
 }
 
+// defaultEventDuration is used for timed events that have no valid 'dur' UDA.
+const defaultEventDuration = 15 * time.Minute
+
+// eventDuration returns how long a task's calendar event should last.
+//
+// It uses the Taskwarrior 'dur' UDA when present and parseable to a positive
+// duration, otherwise it falls back to defaultEventDuration. The result is
+// rounded to whole seconds so it survives the RFC3339 (second-precision)
+// round-trip used for event start/end times, keeping update comparisons stable.
+func eventDuration(task core.Task) time.Duration {
+	if raw := task.GetUDA("dur"); raw != "" {
+		d, err := ParseTaskDuration(raw)
+		if err != nil {
+			slog.Warn("Ignoring invalid 'dur' UDA", "uuid", task.UUID, "value", raw, "error", err)
+		} else if d > 0 {
+			return d.Round(time.Second)
+		}
+	}
+	return defaultEventDuration
+}
+
 // shouldUpdateEvent checks if an event needs to be updated
 func (s *SyncClient) shouldUpdateEvent(task core.Task, event *calendar.Event) bool {
 	slog.Debug("Comparing event with task",
@@ -493,8 +515,25 @@ func (s *SyncClient) shouldUpdateEvent(task core.Task, event *calendar.Event) bo
 			// Compare DateTime for timed events
 			if event.Start.DateTime != "" {
 				eventStartTime, err := time.Parse(time.RFC3339, event.Start.DateTime)
-				if err == nil && !eventStartTime.Equal(taskTime) {
-					return true
+				if err == nil {
+					if !eventStartTime.Equal(taskTime) {
+						return true
+					}
+					// Start matches; verify the event duration still matches the
+					// task's 'dur' UDA (falling back to the default duration).
+					if event.End != nil && event.End.DateTime != "" {
+						eventEndTime, endErr := time.Parse(time.RFC3339, event.End.DateTime)
+						if endErr == nil {
+							actualDuration := eventEndTime.Sub(eventStartTime)
+							if actualDuration != eventDuration(task) {
+								slog.Debug("Event duration changed",
+									"uuid", task.UUID,
+									"expected", eventDuration(task),
+									"actual", actualDuration)
+								return true
+							}
+						}
+					}
 				}
 			} else if event.Start.Date != "" {
 				// Event is all-day but task has time, needs update

--- a/internal/calendar/sync_test.go
+++ b/internal/calendar/sync_test.go
@@ -1,0 +1,104 @@
+package calendar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/clobrano/wui/internal/core"
+	"google.golang.org/api/calendar/v3"
+)
+
+func timedTask(dur string) core.Task {
+	due := time.Date(2026, 7, 8, 14, 0, 0, 0, time.Local)
+	task := core.Task{
+		UUID:        "test-uuid",
+		Description: "Timed task",
+		Status:      "pending",
+		Due:         &due,
+	}
+	if dur != "" {
+		task.UDAs = map[string]string{"dur": dur}
+	}
+	return task
+}
+
+func TestEventDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		dur  string
+		want time.Duration
+	}{
+		{"no uda falls back to default", "", defaultEventDuration},
+		{"iso duration", "PT30M", 30 * time.Minute},
+		{"shorthand duration", "2h", 2 * time.Hour},
+		{"invalid falls back to default", "not-a-duration", defaultEventDuration},
+		{"zero falls back to default", "PT0S", defaultEventDuration},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventDuration(timedTask(tt.dur))
+			if got != tt.want {
+				t.Errorf("eventDuration(dur=%q) = %v, want %v", tt.dur, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskToEventUsesDurUDA(t *testing.T) {
+	s := &SyncClient{}
+
+	// With a dur UDA, the event end should be start + dur.
+	task := timedTask("PT45M")
+	event := s.taskToEvent(task)
+
+	start, err := time.Parse(time.RFC3339, event.Start.DateTime)
+	if err != nil {
+		t.Fatalf("failed to parse start: %v", err)
+	}
+	end, err := time.Parse(time.RFC3339, event.End.DateTime)
+	if err != nil {
+		t.Fatalf("failed to parse end: %v", err)
+	}
+	if got := end.Sub(start); got != 45*time.Minute {
+		t.Errorf("event duration = %v, want %v", got, 45*time.Minute)
+	}
+}
+
+func TestTaskToEventDefaultDuration(t *testing.T) {
+	s := &SyncClient{}
+
+	// Without a dur UDA, the default duration applies.
+	event := s.taskToEvent(timedTask(""))
+
+	start, _ := time.Parse(time.RFC3339, event.Start.DateTime)
+	end, _ := time.Parse(time.RFC3339, event.End.DateTime)
+	if got := end.Sub(start); got != defaultEventDuration {
+		t.Errorf("event duration = %v, want %v", got, defaultEventDuration)
+	}
+}
+
+func TestShouldUpdateEventOnDurationChange(t *testing.T) {
+	s := &SyncClient{}
+
+	// Build an event as it would exist with a 15-minute default duration.
+	baseTask := timedTask("")
+	existing := s.taskToEvent(baseTask)
+
+	// The same task should not need an update.
+	if s.shouldUpdateEvent(baseTask, existing) {
+		t.Errorf("expected no update for unchanged task")
+	}
+
+	// Adding a dur UDA should now require an update to widen the event.
+	changed := timedTask("PT1H")
+	if !s.shouldUpdateEvent(changed, existing) {
+		t.Errorf("expected update when 'dur' UDA changes the event duration")
+	}
+
+	// An event already matching the dur UDA should not need an update.
+	matching := s.taskToEvent(changed)
+	if s.shouldUpdateEvent(changed, matching) {
+		t.Errorf("expected no update when event already matches 'dur' UDA")
+	}
+}


### PR DESCRIPTION
## Summary
Add support for the Taskwarrior `dur` (duration) User Defined Attribute to control the length of timed calendar events. Previously, all timed events defaulted to 15 minutes; now they can be customized via the `dur` UDA while maintaining backward compatibility.

## Key Changes
- **New `duration.go` module**: Implements `ParseTaskDuration()` to parse Taskwarrior duration values in multiple formats:
  - ISO 8601 durations (e.g., `PT30M`, `P1DT2H`) — the format Taskwarrior exports
  - Shorthand notation (e.g., `30min`, `1h30m`, `2d`)
  - Bare numbers (interpreted as seconds, matching Taskwarrior's default)
  - Supports years, months, weeks, days, hours, minutes, and seconds with nominal approximations for calendar-oriented units

- **Updated `sync.go`**:
  - `taskToEvent()` now uses `eventDuration(task)` instead of hardcoded 15-minute duration
  - New `eventDuration()` function reads the `dur` UDA, parses it, and falls back to 15-minute default if missing or invalid
  - Enhanced `shouldUpdateEvent()` to detect when event duration no longer matches the task's `dur` UDA, triggering an update
  - Durations are rounded to whole seconds to ensure stable round-trip through RFC3339 serialization

- **Updated README.md**: Added documentation explaining the `dur` UDA feature with setup instructions and usage examples

## Implementation Details
- The duration parser is lenient and defensive: invalid `dur` values log a warning and fall back to the default rather than failing
- Durations are rounded to second precision to match the RFC3339 datetime format used in Google Calendar, preventing spurious update triggers from floating-point precision differences
- The solution maintains full backward compatibility: tasks without a `dur` UDA continue to use the 15-minute default
- Comprehensive test coverage for both the parser and the sync integration

https://claude.ai/code/session_01PQbKkAy1SHVZSJAYbZaNDr